### PR TITLE
Set up the FastAPI project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # copilot-workspace-test
+
+## Setup Instructions
+
+### 1. Create a virtual environment
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+### 2. Install FastAPI and Uvicorn
+
+```bash
+pip install fastapi uvicorn
+```
+
+### 3. Run the FastAPI application
+
+```bash
+uvicorn app.main:app --reload
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello World"}


### PR DESCRIPTION
Related to #1

Set up the FastAPI project structure.

* Add `app/main.py` with a basic "Hello World" endpoint.
* Add `.gitignore` file to exclude unnecessary files like `__pycache__`, `.env`, and `venv/`.
* Update `README.md` with instructions to create a virtual environment, install FastAPI and Uvicorn, and run the FastAPI application.
* Create the `app` directory.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/realsanket/copilot-workspace-test/pull/2?shareId=fcf8f619-a03d-4363-ae13-c6c18ef81503).